### PR TITLE
kanban操作とAPIの連携

### DIFF
--- a/client/app/components/molecules/GranBoardsList.vue
+++ b/client/app/components/molecules/GranBoardsList.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
     },
     groupId: {
       type: String,
-      default: 'baord-id',
+      default: 'group-id',
     },
     boards: {
       type: Array,
@@ -68,7 +68,7 @@ export default Vue.extend({
   },
   methods: {
     handleListItemClick(boardId: string): void {
-      this.$emit('handleListItemClick', boardId)
+      this.$emit('handleListItemClick', this.groupId, boardId)
     },
     handleAddButton(groupId: string): void {
       this.$emit('handleAddButton', groupId)

--- a/client/app/components/templates/GranBoard.vue
+++ b/client/app/components/templates/GranBoard.vue
@@ -4,6 +4,7 @@
     <div v-for="group in groups" :key="group.id">
       <gran-boards-list
         :name="group.name"
+        :group-id="group.id"
         :boards="group.boards"
         @handleListItemClick="transitionBoardPage"
         @handleAddButton="transitionNewBoardPage"
@@ -27,8 +28,8 @@ export default Vue.extend({
     ...mapGetters('group', ['groups']),
   },
   methods: {
-    transitionBoardPage(boardId: string): void {
-      this.$router.push(`/boards/${boardId}`)
+    transitionBoardPage(groupId: string, boardId: string): void {
+      this.$router.push({ path: `/boards/${boardId}`, query: { groupId } })
     },
     transitionNewBoardPage(_groupId: string): void {
       // todo: groupIDは新規作成の時に使えそうなのでコード上は書いておく

--- a/client/app/components/templates/GranKanban.vue
+++ b/client/app/components/templates/GranKanban.vue
@@ -1,9 +1,9 @@
 <template>
-  <draggable v-model="lists" :component-data="getComponentData()" tag="v-layout">
+  <draggable v-model="columns" :component-data="getComponentData()" tag="v-layout">
     <gran-task-column
       v-for="(column, index) in board.lists"
       :key="column.id"
-      :value="lists[index].tasks"
+      :value="columns[index].tasks"
       :list-index="index"
       :column="column"
       @input="updateTasks"
@@ -29,8 +29,8 @@ export default Vue.extend({
     GranTaskColumn,
   },
   computed: {
-    ...mapGetters('boards', ['board']),
-    lists: {
+    ...mapGetters('boards', ['board', 'lists']),
+    columns: {
       get() {
         return this.board.lists
       },
@@ -39,8 +39,16 @@ export default Vue.extend({
       },
     },
   },
+  watch: {
+    lists: {
+      handler(_val, _old) {
+        this.updateKanban()
+      },
+      deep: true,
+    },
+  },
   methods: {
-    ...mapActions('boards', ['addNewColumn', 'addNewTask']),
+    ...mapActions('boards', ['addNewColumn', 'addNewTask', 'updateKanban']),
     getComponentData(): Object {
       return {
         props: {

--- a/client/app/pages/boards/_id.vue
+++ b/client/app/pages/boards/_id.vue
@@ -11,8 +11,11 @@ export default Vue.extend({
   components: {
     GranKanban,
   },
-  fetch({ store }) {
-    store.dispatch('boards/init')
+  async fetch({ store, route }) {
+    await store.dispatch('boards/getBoardById', {
+      groupId: route.query.groupId,
+      boardId: route.params.id,
+    })
   },
   data: () => ({
     lists: [

--- a/client/app/store/boards.ts
+++ b/client/app/store/boards.ts
@@ -105,10 +105,8 @@ export const actions = {
   // ボードのColumnを追加
   addNewColumn({ commit, state }, formData): Promise<void> {
     const newColumn = {
-      id: Date.now(),
       name: formData.name.value,
       color: formData.color.value,
-      tasks: [],
     }
 
     const groupId: string = state.board.groupId
@@ -116,9 +114,14 @@ export const actions = {
 
     return this.$axios
       .post(`/v1/groups/${groupId}/boards/${boardId}/lists`, newColumn)
-      .then((_res) => {
+      .then((res) => {
+        console.log(res.data)
         // todo: レスポンスで作成したIDを受け取ってそれを使ってstateの書き換えをしたい
-        commit('addColumn', newColumn)
+        commit('addColumn', {
+          ...newColumn,
+          id: res.data.id,
+          tasks: [],
+        })
       })
       .catch((err) => {
         console.log(err)
@@ -143,9 +146,10 @@ export const actions = {
 
     this.$axios
       .post(`/v1/groups/${groupId}/boards/${boardId}/tasks`, newTask.task)
-      .then((_res) => {
+      .then((res) => {
+        console.log(res)
         // todo: レスポンスで作成したIDを受け取ってそれを使ってstateの書き換えをしたい
-        commit('addTask', newTask)
+        commit('addTask', { index: formData.index, task: res.data })
       })
       .catch((err) => {
         console.log(err)

--- a/client/app/store/boards.ts
+++ b/client/app/store/boards.ts
@@ -22,74 +22,9 @@ export const mutations = {
   addTask(state, payload) {
     state.board.lists[payload.index].tasks.push(payload.task)
   },
-  initBoard(state) {
-    state.board = {
-      id: '36de3d32-4d67-4959-9056-23b6763299db',
-      name: 'test board with vuex',
-      closed: false,
-      thumbnailUrl: '',
-      backgroundColor: '#E6EE9C',
-      labels: null,
-      groupId: 'be02c252-d1c3-4e53-9f38-6bdef8e03e3f',
-      lists: [
-        {
-          id: '0ai5jtQZIBtQKrNCT3Bf',
-          name: 'To Do',
-          color: '#009688',
-          tasks: [
-            {
-              id: '65bv2GQawTYMY2Toatao',
-              name: 'テストタスク',
-              labels: [
-                { name: 'Client', color: '#2196F3' },
-                { name: 'API', color: '#F44336' },
-                { name: 'Infra', color: '#FFEB3B' },
-              ],
-              assignedUserIds: null,
-              deadlinedAt: '0001-01-01T00:00:00Z',
-            },
-            {
-              id: '67bv2GQawTYMY2Toatao',
-              name: 'UI設計',
-              labels: [],
-              assignedUserIds: null,
-              deadlinedAt: '0001-01-01T00:00:00Z',
-            },
-          ],
-        },
-        {
-          id: '1ai5jtQZIBtQKrNCT3Bf',
-          name: 'In Prgress',
-          color: '#D81B60',
-          tasks: [
-            {
-              id: '63bv2GQawTYMY2Toatao',
-              name: 'Figma',
-              labels: [],
-              assignedUserIds: null,
-              deadlinedAt: '0001-01-01T00:00:00Z',
-            },
-            {
-              id: '61bv2GQawTYMY2Toatao',
-              name: '本番環境',
-              labels: [],
-              assignedUserIds: null,
-              deadlinedAt: '0001-01-01T00:00:00Z',
-            },
-          ],
-        },
-      ],
-      createdAt: '2020-02-03T12:08:30.540047Z',
-      updatedAt: '2020-02-03T12:08:30.540047Z',
-    }
-  },
 }
 
 export const actions = {
-  init({ commit }) {
-    commit('initBoard')
-  },
-
   getBoardById({ commit }, payload) {
     return new Promise((resolve, reject) => {
       this.$axios


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
- kanbanの操作とapiの連携を行った．
- boardのリストの追加
- taskの追加
- ドラッグ&ドロップでの操作

### レビュー時のポイント

- storeのactionsのコード
- 命名
<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

- それぞれの編集機能を作っていなかった…

### 備考

<!-- マージ後に必要な操作などがあればここに -->